### PR TITLE
fix(stock): Copy Table MultiSelect Values from Template to Variants on Update

### DIFF
--- a/erpnext/controllers/item_variant.py
+++ b/erpnext/controllers/item_variant.py
@@ -344,6 +344,11 @@ def copy_attributes_to_variant(item, variant):
 						if row.get("name"):
 							row.name = None
 						variant.append(field.fieldname, row)
+				elif field.fieldtype == "Table MultiSelect":
+					tbl = item.get(field.fieldname)
+					for row in tbl:
+						row.name = None # force creation of new name
+					variant.set(field.fieldname, tbl)
 				else:
 					variant.set(field.fieldname, item.get(field.fieldname))
 


### PR DESCRIPTION
Added an `elif` branch to `copy_attributes_to_variant` in `erpnext/controllers/item_variant.py` to handle "Table MultiSelect" fields correctly. By setting a row's `name` to `None` an insert is forced rather than an update that would only move a row from one Item to another.

Closes #40213
